### PR TITLE
Parse US formatted date into DateTime object

### DIFF
--- a/lib/omniauth/strategies/concur.rb
+++ b/lib/omniauth/strategies/concur.rb
@@ -1,11 +1,12 @@
 require 'omniauth-oauth2'
+require 'active_support'
 require 'active_support/core_ext'
 
 OAuth2::Response.register_parser(:concur_xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml']) do |body|
   parsed = MultiXml.parse(body).deep_transform_keys{ |key| key.to_s.downcase }['access_token']
   {
     'access_token' => parsed['token'],
-    'expires_at' => parsed['expiration_date'].to_datetime,
+    'expires_at' => DateTime.strptime(parsed['expiration_date'], "%m/%d/%Y %l:%M:%S %p"),
     'refresh_token' => parsed['refresh_token'],
     'instance_url' => parsed['instance_url'],
   }

--- a/spec/omniauth-concur-oauth2_spec.rb
+++ b/spec/omniauth-concur-oauth2_spec.rb
@@ -19,13 +19,13 @@ describe OmniAuth::Strategies::Concur do
         <Access_Token>
           <Instance_Url>https://www.concursolutions.com/</Instance_Url>
           <Token>foobar</Token>
-          <Expiration_date>12/10/2015 5:02:12 PM</Expiration_date>
+          <Expiration_date>1/13/2017 5:02:12 PM</Expiration_date>
           <Refresh_Token>barbaz</Refresh_Token>
         </Access_Token>
       XML
       expected = {
         'access_token' => 'foobar',
-        'expires_at' => DateTime.parse('12/10/2015 5:02:12 PM'),
+        'expires_at' => DateTime.parse('2017-1-13 17:02:12'),
         'refresh_token' => 'barbaz',
         'instance_url' => 'https://www.concursolutions.com/',
       }


### PR DESCRIPTION
- previously was parsing day and month in reverse
- '1/12/2017' would result in '2017-12-01'
- '1/13/2017' would result in 'invalid date' ArgumentError
