### PR TITLE
Bump for Rails 5.0

### DIFF
--- a/lib/omniauth/strategies/concur.rb
+++ b/lib/omniauth/strategies/concur.rb
@@ -3,13 +3,18 @@ require 'active_support'
 require 'active_support/core_ext'
 
 OAuth2::Response.register_parser(:concur_xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml']) do |body|
-  parsed = MultiXml.parse(body).deep_transform_keys{ |key| key.to_s.downcase }['access_token']
-  {
-    'access_token' => parsed['token'],
-    'expires_at' => DateTime.strptime(parsed['expiration_date'], "%m/%d/%Y %l:%M:%S %p"),
-    'refresh_token' => parsed['refresh_token'],
-    'instance_url' => parsed['instance_url'],
-  }
+  parsed = MultiXml.parse(body).deep_transform_keys { |key| key.to_s.downcase }
+  if parsed.key?('access_token')
+    access_token = parsed['access_token']
+    {
+        'access_token' => access_token['token'],
+        'expires_at' => DateTime.strptime(access_token['expiration_date'], "%m/%d/%Y %l:%M:%S %p"),
+        'refresh_token' => access_token['refresh_token'],
+        'instance_url' => access_token['instance_url'],
+    }
+  else
+    OAuth2::Response.class_variable_get(:@@parsers)[:xml].call(body)
+  end
 end
 
 module OmniAuth

--- a/omniauth-concur-oauth2.gemspec
+++ b/omniauth-concur-oauth2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'activesupport', '~> 4.0'
+  s.add_dependency 'activesupport', '~> 5.0'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'
 end
 

--- a/spec/omniauth-concur-oauth2_spec.rb
+++ b/spec/omniauth-concur-oauth2_spec.rb
@@ -13,7 +13,8 @@ describe OmniAuth::Strategies::Concur do
   end
 
   describe ':concur_xml response parser' do
-    let(:parser) {OAuth2::Response::PARSERS[:concur_xml]}
+    let(:parser) { OAuth2::Response.class_variable_get(:@@parsers)[:concur_xml] }
+
     it 'parse correctly' do
       data = <<-XML
         <Access_Token>
@@ -24,10 +25,10 @@ describe OmniAuth::Strategies::Concur do
         </Access_Token>
       XML
       expected = {
-        'access_token' => 'foobar',
-        'expires_at' => DateTime.parse('2017-1-13 17:02:12'),
-        'refresh_token' => 'barbaz',
-        'instance_url' => 'https://www.concursolutions.com/',
+          'access_token' => 'foobar',
+          'expires_at' => DateTime.parse('2017-1-13 17:02:12'),
+          'refresh_token' => 'barbaz',
+          'instance_url' => 'https://www.concursolutions.com/',
       }
       expect(parser.call(data)).to eq(expected)
     end

--- a/spec/omniauth-concur-oauth2_spec.rb
+++ b/spec/omniauth-concur-oauth2_spec.rb
@@ -32,6 +32,15 @@ describe OmniAuth::Strategies::Concur do
       }
       expect(parser.call(data)).to eq(expected)
     end
+
+    context "when it gets some XML that doesn't match what we expect from concur" do
+      it 'parses the XML' do
+        data = <<-XML
+          <Foo>my xml</Foo>
+        XML
+        expect(parser.call(data)).to eq({ 'Foo' => 'my xml' })
+      end
+    end
   end
 
   describe 'client options' do


### PR DESCRIPTION
This PR bumps dependencies to get a successful bundle in Konekti. We should do some due diligence to make sure that this makes sense.

In particular, it would be nice to instead have a more permissive version set. More information about declaring gem dependencies can be found here:

https://guides.rubygems.org/patterns/#declaring-dependencies