### PR TITLE
Bump omniauth-oauth2 dependency version

### DIFF
--- a/omniauth-concur-oauth2.gemspec
+++ b/omniauth-concur-oauth2.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'activesupport', '~> 4.0'
-  s.add_dependency 'omniauth-oauth2', '~> 1.1'
+  s.add_dependency 'omniauth-oauth2', '~> 1.3.1'
 end
 


### PR DESCRIPTION
This PR updates the `omniauth-oauth2` dependency to 1.3.1 to allow using a later version (>0.10) of `faraday` in konekti. We need to bump `faraday` in konekti to use the `qualtrics_api` gem.

I tested creating all oauth services after the dependency bump and everything is working as expected.