### PR TITLE
Alter to allow rails versions from 5.x to 6.1.x.

### DIFF
--- a/omniauth-concur-oauth2.gemspec
+++ b/omniauth-concur-oauth2.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'activesupport', '>= 5.0', '< 6.1.0'
+  s.add_dependency 'activesupport', '>= 5.0', '< 7.0.0'
   s.add_dependency 'omniauth-oauth2', '>= 1.3.1'
 end


### PR DESCRIPTION
As we are spiking on how to proper update our rails versions to 6.1, we need to bump first our dependencies that are not currently allowing the rails 6. 