### PR TITLE
IE-591 Update libxml-ruby dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.gem
 .bundle
-Gemfile.lock
 pkg/*
 rcov generated
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 pkg/*
 rcov generated
 coverage
+.idea/
 
 rdoc generated
 rdoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,91 @@
+PATH
+  remote: .
+  specs:
+    omniauth-concur-oauth2 (0.0.3)
+      activesupport (>= 5.0, < 7.0.0)
+      libxml-ruby (~> 5.0)
+      omniauth-oauth2 (>= 1.7.1)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activesupport (6.1.7.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    base64 (0.2.0)
+    concurrent-ruby (1.2.3)
+    diff-lcs (1.5.1)
+    docile (1.4.0)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    hashie (5.0.0)
+    i18n (1.14.4)
+      concurrent-ruby (~> 1.0)
+    jwt (2.8.1)
+      base64
+    libxml-ruby (5.0.3)
+    minitest (5.22.3)
+    multi_xml (0.6.0)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    rack (3.0.10)
+    rack-protection (3.0.6)
+      rack
+    rake (13.1.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    version_gem (1.1.4)
+    zeitwerk (2.6.13)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  omniauth-concur-oauth2!
+  rake
+  rspec
+  simplecov
+
+BUNDLED WITH
+   2.4.22

--- a/lib/omniauth-concur-oauth2/version.rb
+++ b/lib/omniauth-concur-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Concur
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end


### PR DESCRIPTION
[Fix incompatible function pointer type error in Ominauth-concur-oauth2](https://kantata.atlassian.net/browse/IE-591)

- Updated patch version to `0.0.4`